### PR TITLE
Introducing Spell Effects

### DIFF
--- a/codex/spells/spells-wizard-evocation-1.sol
+++ b/codex/spells/spells-wizard-evocation-1.sol
@@ -7,29 +7,6 @@ contract codex {
     string constant public school = "Evocation";
     uint constant public level = 1;
 
-
-    struct effect {
-        string name;            // name of mod when seen on item/creature, e.g. "+1 damage"
-        string description;     // description of mod effect " this gives +1 damage for a successful attack"
-        uint32 expiry;         // expiry = timestamp when effect ends: permanency is 100 years
-    
-        int[4] damage; // dice number, dice type, adjustment, level multiplier. 2d4 +1 with additional 1d4 per level = (2,4,1,1). curing 10 hp with potion is (0,0,-10,0), 
-        int ac_adjustment; // e.g. +1 to AC
-        int hp_adjustment; // e.g. +1 to HP
-    
-        int[8] roll_adjustment ; // e.g. +1/-1 to rolls on str, dex, con, int, wis, cha, attack, initiative
-        int[8] roll_advantage ; // advantage to rolls on str, dex, con, int, wis, cha, attack, initiative
-        int[8] roll_disadvantage ; // disadvantage to rolls on str, dex, con, int, wis, cha, attack, initiative
-    
-        int[6] save_adjustment ; // e.g. +1/-1 to saving rolls on str, dex, con, int, wis, cha, attack, initiative
-        int[6] save_advantage ; // e.g. advantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
-        int[6] save_disadvantage ; // e.g. disadvantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
-
-        uint conjured_id;           
-        uint conjured_type;        // item, creature, armour, weapon
-    } 
-    // cast_spell() will get the modifier from codex and apply level bonuses etc 
-
     function spell_by_id(uint _id) external pure returns(
         uint id,
         string memory name,
@@ -43,8 +20,7 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description,
-        effect memory _effect
+        string memory description
     ) {
         if (_id == 28) {
             return burning_hands();
@@ -57,12 +33,9 @@ contract codex {
         }
     }
 
-
-    // calling function, e.g. cast_spell() will apply modifiers (duration, damage), set summon type 
-
     function burning_hands() public pure returns (
         uint id,
-        string memory name, // spell name
+        string memory name,
         bool verbal,
         bool somatic,
         bool focus,
@@ -73,9 +46,7 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description, // spell description
-        uint duration_multi,
-        effect memory _effect
+        string memory description
     ) {
         id = 28;
         name = "Burning Hands";
@@ -90,22 +61,7 @@ contract codex {
         saving_throw_effect = 2;
         spell_resistance = true;
         description = "A cone of searing flame shoots from your fingertips. Any creature in the area of the flames takes 1d4 points of fire damage per caster level (maximum 5d4). Flammable materials burn if the flames touch them. A character can extinguish burning items as a full-round action.";
-        duration_multi = 0
-        // QUESTION ON SOLIDITY: I assume unassigned _effect values are zero and can be tested for later
-        _effect.name = "Burning Damage"
-        _effect.description = "It burns!";     // description of mod effect " this gives +1 damage for a successful attack"
-        _effect.expiry = ?;         // expiry = timestamp when effect ends: permanency is 100 years
-        _effect.damage = (1,4,0,1); // dice, type, adjustment, level multiplier. 2d4 +3 @ that adds 1 dice per level is = (2,4,3,1). curing 10 hp is (0,0,-10, 0), 
-        //_effect.ac = 0; // e.g. +1 to AC
-        //_effect.hp = 0
-        //_effect.roll_adjustment = [0,0,0,0,0,0,0,0]; // e.g. +1/-1 to rolls on str, dex, con, int, wis, cha, attack, initiative
-        //_effect.roll_advantage ; // advantage to rolls on str, dex, con, int, wis, cha, attack, initiative
-        //_effect.roll_disadvantage ; // disadvantage to rolls on str, dex, con, int, wis, cha, attack, initiative
-    
-        //_effect.save_adjustment ; // e.g. +1/-1 to saving rolls on str, dex, con, int, wis, cha, attack, initiative
-        //_effect.save_advantage ; // e.g. advantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
-        //_effect.save_disadvantage ; // e.g. disadvantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
-        }
+    }
 
     function floating_disk() public pure returns (
         uint id,
@@ -120,9 +76,7 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description,
-        uint duration_multi,
-        effect memory _effect
+        string memory description
     ) {
         id = 29;
         name = "Floating Disk";
@@ -137,9 +91,6 @@ contract codex {
         saving_throw_effect = 0;
         spell_resistance = false;
         description = "You create a slightly concave, circular plane of force that follows you about and carries loads for you. The disk is 3 feet in diameter and 1 inch deep at its center. It can hold 100 pounds of weight per caster level. (If used to transport a liquid, its capacity is 2 gallons.)";
-        duration_multi = 0
-        //_effect.summon = magic_item_id or monster_id or magic_weapon_id 
-        _effect.description = "A circular disk is hovering nearby"; 
     }
 
     function magic_missile() public pure returns (
@@ -155,9 +106,7 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description,
-        uint duration_multi,
-        effect memory _effect
+        string memory description
     ) {
         id = 30;
         name = "Magic Missle";
@@ -172,8 +121,6 @@ contract codex {
         saving_throw_effect = 0;
         spell_resistance = true;
         description = "A missile of magical energy darts forth from your fingertip and strikes its target, dealing 1d4+1 points of force damage. The missile strikes unerringly, even if the target is in melee combat or has less than total cover or total concealment.";
-        duration_multi = 0
-        _effect.damage = (1,4,1,1); // dice, type, adjustment, level multiplier. 2d4 +3 @ that adds 1 dice per level is = (2,4,3,1). curing 10 hp is (0,0,-10, 0), 
     }
 
     function shocking_grasp() public pure returns (
@@ -189,9 +136,7 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description,
-        uint duration_multi,
-        effect memory _effect
+        string memory description
     ) {
         id = 10;
         name = "Ray of Frost";
@@ -206,7 +151,5 @@ contract codex {
         saving_throw_effect = 0;
         spell_resistance = true;
         description = "Your successful melee touch attack deals 1d6 points of electricity damage per caster level (maximum 5d6). When delivering the jolt, you gain a +3 bonus on attack rolls if the opponent is wearing metal armor (or made out of metal, carrying a lot of metal, or the like).";
-        duration_multi = 0
-        _effect.damage = (1,6,1,1); // dice, type, adjustment, level multiplier. 2d4 +3 @ that adds 1 dice per level is = (2,4,3,1). curing 10 hp is (0,0,-10, 0), 
     }
 }

--- a/codex/spells/spells-wizard-evocation-1.sol
+++ b/codex/spells/spells-wizard-evocation-1.sol
@@ -46,6 +46,7 @@ contract codex {
         uint saving_throw_effect,
         bool spell_resistance,
         string memory description,
+        uint duration_multi,
         effect memory _effect
     ) {
         if (_id == 28) {
@@ -93,20 +94,8 @@ contract codex {
         spell_resistance = true;
         description = "A cone of searing flame shoots from your fingertips. Any creature in the area of the flames takes 1d4 points of fire damage per caster level (maximum 5d4). Flammable materials burn if the flames touch them. A character can extinguish burning items as a full-round action.";
         duration_multi = 0
-        // QUESTION ON SOLIDITY: I assume unassigned _effect values are zero and can be tested for later
-        _effect.name = "Burning Damage"
-        _effect.description = "It burns!";     // description of mod effect " this gives +1 damage for a successful attack"
-        _effect.expiry = ?;         // expiry = timestamp when effect ends: permanency is 100 years
-        _effect.damage = (1,4,0,1); // dice, type, adjustment, level multiplier. 2d4 +3 @ that adds 1 dice per level is = (2,4,3,1). curing 10 hp is (0,0,-10, 0), 
-        //_effect.ac = 0; // e.g. +1 to AC
-        //_effect.hp = 0
-        //_effect.roll_adjustment = [0,0,0,0,0,0,0,0]; // e.g. +1/-1 to rolls on str, dex, con, int, wis, cha, attack, initiative
-        //_effect.roll_advantage ; // advantage to rolls on str, dex, con, int, wis, cha, attack, initiative
-        //_effect.roll_disadvantage ; // disadvantage to rolls on str, dex, con, int, wis, cha, attack, initiative
-    
-        //_effect.save_adjustment ; // e.g. +1/-1 to saving rolls on str, dex, con, int, wis, cha, attack, initiative
-        //_effect.save_advantage ; // e.g. advantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
-        //_effect.save_disadvantage ; // e.g. disadvantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+        // n.b. assuming unassigned _effect values are zero and can be tested for later
+        _effect.damage = (1,4,0,1); // dice, type, adjustment, level multiplier
         }
 
     function floating_disk() public pure returns (

--- a/codex/spells/spells-wizard-evocation-1.sol
+++ b/codex/spells/spells-wizard-evocation-1.sol
@@ -7,6 +7,31 @@ contract codex {
     string constant public school = "Evocation";
     uint constant public level = 1;
 
+
+    struct effect {
+        string name;            // name of mod when seen on item/creature, e.g. "+1 damage"
+        string description;     // description of mod effect " this gives +1 damage for a successful attack"
+        uint32 expiry;         // expiry = timestamp when effect ends: permanency is 100 years
+    
+        int[4] damage; // dice number, dice type, adjustment, level multiplier. 
+        //2d4 +1 with additional 1d4 per level = (2,4,1,1). curing 10 hp with potion is (0,0,-10,0), 
+        
+        int ac_adjustment; // e.g. +1 to AC
+        int hp_adjustment; // e.g. +1 to HP
+    
+        int[8] roll_adjustment ; // e.g. +1/-1 to rolls on str, dex, con, int, wis, cha, attack, initiative
+        int[8] roll_advantage ; // advantage to rolls on str, dex, con, int, wis, cha, attack, initiative
+        int[8] roll_disadvantage ; // disadvantage to rolls on str, dex, con, int, wis, cha, attack, initiative
+    
+        int[6] save_adjustment ; // e.g. +1/-1 to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+        int[6] save_advantage ; // e.g. advantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+        int[6] save_disadvantage ; // e.g. disadvantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+
+        uint conjured_id;           
+        uint conjured_type;        // item, creature, armour, weapon, nature
+    } 
+
+
     function spell_by_id(uint _id) external pure returns(
         uint id,
         string memory name,
@@ -20,7 +45,8 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description
+        string memory description,
+        effect memory _effect
     ) {
         if (_id == 28) {
             return burning_hands();
@@ -33,9 +59,12 @@ contract codex {
         }
     }
 
+
+    // calling function, e.g. cast_spell() will apply modifiers (duration, damage), set summon type 
+
     function burning_hands() public pure returns (
         uint id,
-        string memory name,
+        string memory name, // spell name
         bool verbal,
         bool somatic,
         bool focus,
@@ -46,7 +75,9 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description
+        string memory description, // spell description
+        uint duration_multi,
+        effect memory _effect
     ) {
         id = 28;
         name = "Burning Hands";
@@ -61,7 +92,22 @@ contract codex {
         saving_throw_effect = 2;
         spell_resistance = true;
         description = "A cone of searing flame shoots from your fingertips. Any creature in the area of the flames takes 1d4 points of fire damage per caster level (maximum 5d4). Flammable materials burn if the flames touch them. A character can extinguish burning items as a full-round action.";
-    }
+        duration_multi = 0
+        // QUESTION ON SOLIDITY: I assume unassigned _effect values are zero and can be tested for later
+        _effect.name = "Burning Damage"
+        _effect.description = "It burns!";     // description of mod effect " this gives +1 damage for a successful attack"
+        _effect.expiry = ?;         // expiry = timestamp when effect ends: permanency is 100 years
+        _effect.damage = (1,4,0,1); // dice, type, adjustment, level multiplier. 2d4 +3 @ that adds 1 dice per level is = (2,4,3,1). curing 10 hp is (0,0,-10, 0), 
+        //_effect.ac = 0; // e.g. +1 to AC
+        //_effect.hp = 0
+        //_effect.roll_adjustment = [0,0,0,0,0,0,0,0]; // e.g. +1/-1 to rolls on str, dex, con, int, wis, cha, attack, initiative
+        //_effect.roll_advantage ; // advantage to rolls on str, dex, con, int, wis, cha, attack, initiative
+        //_effect.roll_disadvantage ; // disadvantage to rolls on str, dex, con, int, wis, cha, attack, initiative
+    
+        //_effect.save_adjustment ; // e.g. +1/-1 to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+        //_effect.save_advantage ; // e.g. advantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+        //_effect.save_disadvantage ; // e.g. disadvantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+        }
 
     function floating_disk() public pure returns (
         uint id,
@@ -76,7 +122,9 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description
+        string memory description,
+        uint duration_multi,
+        effect memory _effect
     ) {
         id = 29;
         name = "Floating Disk";
@@ -91,6 +139,9 @@ contract codex {
         saving_throw_effect = 0;
         spell_resistance = false;
         description = "You create a slightly concave, circular plane of force that follows you about and carries loads for you. The disk is 3 feet in diameter and 1 inch deep at its center. It can hold 100 pounds of weight per caster level. (If used to transport a liquid, its capacity is 2 gallons.)";
+        duration_multi = 0
+        //_effect.summon = magic_item_id or monster_id or magic_weapon_id 
+        _effect.description = "A circular disk is hovering nearby"; 
     }
 
     function magic_missile() public pure returns (
@@ -106,7 +157,9 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description
+        string memory description,
+        uint duration_multi,
+        effect memory _effect
     ) {
         id = 30;
         name = "Magic Missle";
@@ -121,6 +174,8 @@ contract codex {
         saving_throw_effect = 0;
         spell_resistance = true;
         description = "A missile of magical energy darts forth from your fingertip and strikes its target, dealing 1d4+1 points of force damage. The missile strikes unerringly, even if the target is in melee combat or has less than total cover or total concealment.";
+        duration_multi = 0
+        _effect.damage = (1,4,1,1); // dice, type, adjustment, level multiplier. 2d4 +3 @ that adds 1 dice per level is = (2,4,3,1). curing 10 hp is (0,0,-10, 0), 
     }
 
     function shocking_grasp() public pure returns (
@@ -136,7 +191,9 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description
+        string memory description,
+        uint duration_multi,
+        effect memory _effect
     ) {
         id = 10;
         name = "Ray of Frost";
@@ -151,5 +208,7 @@ contract codex {
         saving_throw_effect = 0;
         spell_resistance = true;
         description = "Your successful melee touch attack deals 1d6 points of electricity damage per caster level (maximum 5d6). When delivering the jolt, you gain a +3 bonus on attack rolls if the opponent is wearing metal armor (or made out of metal, carrying a lot of metal, or the like).";
+        duration_multi = 0
+        _effect.damage = (1,6,1,1); // dice, type, adjustment, level multiplier. 2d4 +3 @ that adds 1 dice per level is = (2,4,3,1). curing 10 hp is (0,0,-10, 0), 
     }
 }

--- a/codex/spells/spells-wizard-evocation-1.sol
+++ b/codex/spells/spells-wizard-evocation-1.sol
@@ -7,6 +7,29 @@ contract codex {
     string constant public school = "Evocation";
     uint constant public level = 1;
 
+
+    struct effect {
+        string name;            // name of mod when seen on item/creature, e.g. "+1 damage"
+        string description;     // description of mod effect " this gives +1 damage for a successful attack"
+        uint32 expiry;         // expiry = timestamp when effect ends: permanency is 100 years
+    
+        int[4] damage; // dice number, dice type, adjustment, level multiplier. 2d4 +1 with additional 1d4 per level = (2,4,1,1). curing 10 hp with potion is (0,0,-10,0), 
+        int ac_adjustment; // e.g. +1 to AC
+        int hp_adjustment; // e.g. +1 to HP
+    
+        int[8] roll_adjustment ; // e.g. +1/-1 to rolls on str, dex, con, int, wis, cha, attack, initiative
+        int[8] roll_advantage ; // advantage to rolls on str, dex, con, int, wis, cha, attack, initiative
+        int[8] roll_disadvantage ; // disadvantage to rolls on str, dex, con, int, wis, cha, attack, initiative
+    
+        int[6] save_adjustment ; // e.g. +1/-1 to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+        int[6] save_advantage ; // e.g. advantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+        int[6] save_disadvantage ; // e.g. disadvantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+
+        uint conjured_id;           
+        uint conjured_type;        // item, creature, armour, weapon
+    } 
+    // cast_spell() will get the modifier from codex and apply level bonuses etc 
+
     function spell_by_id(uint _id) external pure returns(
         uint id,
         string memory name,
@@ -20,7 +43,8 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description
+        string memory description,
+        effect memory _effect
     ) {
         if (_id == 28) {
             return burning_hands();
@@ -33,9 +57,12 @@ contract codex {
         }
     }
 
+
+    // calling function, e.g. cast_spell() will apply modifiers (duration, damage), set summon type 
+
     function burning_hands() public pure returns (
         uint id,
-        string memory name,
+        string memory name, // spell name
         bool verbal,
         bool somatic,
         bool focus,
@@ -46,7 +73,9 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description
+        string memory description, // spell description
+        uint duration_multi,
+        effect memory _effect
     ) {
         id = 28;
         name = "Burning Hands";
@@ -61,7 +90,22 @@ contract codex {
         saving_throw_effect = 2;
         spell_resistance = true;
         description = "A cone of searing flame shoots from your fingertips. Any creature in the area of the flames takes 1d4 points of fire damage per caster level (maximum 5d4). Flammable materials burn if the flames touch them. A character can extinguish burning items as a full-round action.";
-    }
+        duration_multi = 0
+        // QUESTION ON SOLIDITY: I assume unassigned _effect values are zero and can be tested for later
+        _effect.name = "Burning Damage"
+        _effect.description = "It burns!";     // description of mod effect " this gives +1 damage for a successful attack"
+        _effect.expiry = ?;         // expiry = timestamp when effect ends: permanency is 100 years
+        _effect.damage = (1,4,0,1); // dice, type, adjustment, level multiplier. 2d4 +3 @ that adds 1 dice per level is = (2,4,3,1). curing 10 hp is (0,0,-10, 0), 
+        //_effect.ac = 0; // e.g. +1 to AC
+        //_effect.hp = 0
+        //_effect.roll_adjustment = [0,0,0,0,0,0,0,0]; // e.g. +1/-1 to rolls on str, dex, con, int, wis, cha, attack, initiative
+        //_effect.roll_advantage ; // advantage to rolls on str, dex, con, int, wis, cha, attack, initiative
+        //_effect.roll_disadvantage ; // disadvantage to rolls on str, dex, con, int, wis, cha, attack, initiative
+    
+        //_effect.save_adjustment ; // e.g. +1/-1 to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+        //_effect.save_advantage ; // e.g. advantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+        //_effect.save_disadvantage ; // e.g. disadvantage to saving rolls on str, dex, con, int, wis, cha, attack, initiative
+        }
 
     function floating_disk() public pure returns (
         uint id,
@@ -76,7 +120,9 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description
+        string memory description,
+        uint duration_multi,
+        effect memory _effect
     ) {
         id = 29;
         name = "Floating Disk";
@@ -91,6 +137,9 @@ contract codex {
         saving_throw_effect = 0;
         spell_resistance = false;
         description = "You create a slightly concave, circular plane of force that follows you about and carries loads for you. The disk is 3 feet in diameter and 1 inch deep at its center. It can hold 100 pounds of weight per caster level. (If used to transport a liquid, its capacity is 2 gallons.)";
+        duration_multi = 0
+        //_effect.summon = magic_item_id or monster_id or magic_weapon_id 
+        _effect.description = "A circular disk is hovering nearby"; 
     }
 
     function magic_missile() public pure returns (
@@ -106,7 +155,9 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description
+        string memory description,
+        uint duration_multi,
+        effect memory _effect
     ) {
         id = 30;
         name = "Magic Missle";
@@ -121,6 +172,8 @@ contract codex {
         saving_throw_effect = 0;
         spell_resistance = true;
         description = "A missile of magical energy darts forth from your fingertip and strikes its target, dealing 1d4+1 points of force damage. The missile strikes unerringly, even if the target is in melee combat or has less than total cover or total concealment.";
+        duration_multi = 0
+        _effect.damage = (1,4,1,1); // dice, type, adjustment, level multiplier. 2d4 +3 @ that adds 1 dice per level is = (2,4,3,1). curing 10 hp is (0,0,-10, 0), 
     }
 
     function shocking_grasp() public pure returns (
@@ -136,7 +189,9 @@ contract codex {
         uint saving_throw_type,
         uint saving_throw_effect,
         bool spell_resistance,
-        string memory description
+        string memory description,
+        uint duration_multi,
+        effect memory _effect
     ) {
         id = 10;
         name = "Ray of Frost";
@@ -151,5 +206,7 @@ contract codex {
         saving_throw_effect = 0;
         spell_resistance = true;
         description = "Your successful melee touch attack deals 1d6 points of electricity damage per caster level (maximum 5d6). When delivering the jolt, you gain a +3 bonus on attack rolls if the opponent is wearing metal armor (or made out of metal, carrying a lot of metal, or the like).";
+        duration_multi = 0
+        _effect.damage = (1,6,1,1); // dice, type, adjustment, level multiplier. 2d4 +3 @ that adds 1 dice per level is = (2,4,3,1). curing 10 hp is (0,0,-10, 0), 
     }
 }


### PR DESCRIPTION
reusable struct for applying spell effect to summoners, weapons, armour, items, creatures.
configurable struct should be flexible for most spells, and includes placeholder for spells summoning weapons, items and beings

Andre please confirm this approach is suitable before I refactor spell codex. Next step after that is applying effects through rarity_casting.sol, with reuse for "Craft Magic Arms And Armor" feat. Supports variety for items created in economy and/or found in dungeons


